### PR TITLE
Fix for OP_Div Sign Evaluation

### DIFF
--- a/rtl/fwrisc_mul_div_shift.sv
+++ b/rtl/fwrisc_mul_div_shift.sv
@@ -126,7 +126,7 @@ module fwrisc_mul_div_shift #(
 					end
 				endcase
 				if (op == OP_DIV) begin
-					div_sign <= (in_a[31] != in_a[31]);
+					div_sign <= (in_a[31] != in_b[31]);
 				end else begin
 					// OP_REM and others
 					div_sign <= in_a[31];


### PR DESCRIPTION
I changed the code in the module I mentioned in the issue [#2](https://github.com/Featherweight-IP/fwrisc/issues/2). After fixing the specified line of code, the DIV operation is working fine when the operands have opposite signs. Do approve my pull request if you consider it as a solution to the issue. 

I loved working on FWRISC as I got alot of knowledge while working on it. 

Regards.